### PR TITLE
Use path.join instead of specified backslash for file separators

### DIFF
--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -38,4 +38,4 @@ pub const TYPE_STRING_UTF8: [u8; 2] = [0xAC, 0x08];
 pub const TYPE_STRING_UTF16: [u8; 2] = [0x9C, 0x16];
 
 
-pub const SCRIPTSLOG_PATH_IN_DOCS: &str = "The Witcher 3\\scriptslog.txt";
+pub const SCRIPTSLOG_FILE_NAME: &str = "scriptslog.txt";

--- a/src/core/scriptslog.rs
+++ b/src/core/scriptslog.rs
@@ -1,4 +1,4 @@
-use std::{fs::{File, OpenOptions}, sync::mpsc::{Receiver, TryRecvError}, io::{BufReader, Seek, SeekFrom, Read}, time::Duration};
+use std::{fs::{File, OpenOptions}, sync::mpsc::{Receiver, TryRecvError}, io::{BufReader, Seek, SeekFrom, Read}, time::Duration, path::Path};
 use directories::UserDirs;
 
 use crate::constants;
@@ -67,11 +67,13 @@ fn scriptslog_file() -> Result<File, String> {
     }
 
     if let Some(docs) = docs {
+        let scriptslog_path = Path::new(&docs).join(Path::new("The Witcher 3").join(constants::SCRIPTSLOG_FILE_NAME));
+
         let file = OpenOptions::new()
             .read(true)
             .write(true) // so that it can be created if doesn't exist
             .create(true)
-            .open( docs + "\\" + constants::SCRIPTSLOG_PATH_IN_DOCS );
+            .open( scriptslog_path );
 
         if let Err(e) = file {
             println!("{:?}", e.kind());

--- a/src/core/scriptslog.rs
+++ b/src/core/scriptslog.rs
@@ -60,14 +60,12 @@ fn scriptslog_file() -> Result<File, String> {
     let mut docs = None;
     if let Some(ud) = UserDirs::new() {
         if let Some(path) = ud.document_dir() {
-            if let Some(s) = path.to_str() {
-                docs = Some(s.to_owned());
-            }
+            docs = Some(path.to_owned());
         }
     }
 
     if let Some(docs) = docs {
-        let scriptslog_path = Path::new(&docs).join(Path::new("The Witcher 3").join(constants::SCRIPTSLOG_FILE_NAME));
+        let scriptslog_path = docs.join(Path::new("The Witcher 3").join(constants::SCRIPTSLOG_FILE_NAME));
 
         let file = OpenOptions::new()
             .read(true)


### PR DESCRIPTION
The path.join function will use whatever file separator is used by the host OS instead of just backslashes.