### PR TITLE
Add build check and release draft workflows

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,35 @@
+name: check-build
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: '*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: x86_64-pc-windows-gnu
+        override: true
+    - name: Build with Cargo
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: build
+        args: --release --target=x86_64-pc-windows-gnu
+    - name: Run tests
+      run: echo "Tests are not yet set up, assume everything works because why not."
+      # Add once testing is configured
+      # run: cargo test --verbose

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -30,6 +30,4 @@ jobs:
         command: build
         args: --release --target=x86_64-pc-windows-gnu
     - name: Run tests
-      run: echo "Tests are not yet set up, assume everything works because why not."
-      # Add once testing is configured
-      # run: cargo test --verbose
+      run: cargo test --verbose

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,35 @@
+name: draft-release
+
+on:
+  push:
+    tags: '*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: x86_64-pc-windows-gnu
+        override: true
+    - name: Build with Cargo
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: build
+        args: --release --target=x86_64-pc-windows-gnu
+    - name: Create draft release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "target/x86_64-pc-windows-gnu/release/tw3-modlist-manager.exe"
+        draft: true
+        generateReleaseNotes: true

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Create draft release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "target/x86_64-pc-windows-gnu/release/tw3-modlist-manager.exe"
+        artifacts: "target/x86_64-pc-windows-gnu/release/rw3d_cli.exe"
         draft: true
         generateReleaseNotes: true


### PR DESCRIPTION
There are two workflows added:
1. Check build on any push to make sure it's functional
2. Draft a non-public release on tag

~~<sub>these are totally not copied from the ones I wrote for aeltoth</sub>~~