### PR TITLE
Add shorthand for verbose

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -31,7 +31,7 @@ pub(crate) struct CliOptions {
     no_listen: bool,
 
     /// Enable verbose printing of packet contents.
-    #[clap(long)]
+    #[clap(long, short)]
     verbose: bool,
 
     /// Execute command immediately without doing short breaks between info messages beforehand.


### PR DESCRIPTION
I feel like a lowercase "v" is pretty standard for verbose so I think it should be added for convenience as shorthand.
