### PR TITLE
Add support for Linux scriptslog path

### DIFF
--- a/src/cli/local_subcommands.rs
+++ b/src/cli/local_subcommands.rs
@@ -21,7 +21,11 @@ pub(crate) enum LocalSubcommands {
 
         /// Filter out lines that do not containt highlighted text
         #[clap(short, long)]
-        filter_non_highlighted: bool
+        filter_non_highlighted: bool,
+
+        /// Specify a custom, full path to the scriptslog file
+        #[clap(short='p', long)]
+        custom_path: Option<String>
     }
 }
 
@@ -57,9 +61,9 @@ pub(crate) fn handle_local_subcommand( cmd: LocalSubcommands, options: CliOption
     if !options.no_wait { thread::sleep( Duration::from_millis(3000) ) }
 
     match cmd {
-        LocalSubcommands::Scriptslog { colors, refresh_time, filter_non_highlighted } => {
+        LocalSubcommands::Scriptslog { colors, refresh_time, filter_non_highlighted, custom_path } => {
             let highlights = scriptslog_colors_to_highlight_records(colors);
-            if let Some(err) = rw3d_core::scriptslog::tail_scriptslog(|text| scriptslog_printer(text, &highlights, filter_non_highlighted), refresh_time, logger_rcv) {
+            if let Some(err) = rw3d_core::scriptslog::tail_scriptslog(|text| scriptslog_printer(text, &highlights, filter_non_highlighted), refresh_time, logger_rcv, custom_path) {
                 println!("{}", err);
             }
         }

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -39,3 +39,4 @@ pub const TYPE_STRING_UTF16: [u8; 2] = [0x9C, 0x16];
 
 
 pub const SCRIPTSLOG_FILE_NAME: &str = "scriptslog.txt";
+pub const LINUX_STEAM_PFX_PATH: &str = ".local/share/Steam/steamapps/compatdata/292030/pfx/drive_c/users/steamuser/Documents"; // it's ok to use forward slashes because this is Linux-specific

--- a/src/core/scriptslog.rs
+++ b/src/core/scriptslog.rs
@@ -59,8 +59,16 @@ where P: Fn(&String) -> () {
 fn scriptslog_file() -> Result<File, String> {
     let mut docs = None;
     if let Some(ud) = UserDirs::new() {
-        if let Some(path) = ud.document_dir() {
-            docs = Some(path.to_owned());
+        if cfg!(windows) {
+            if let Some(path) = ud.document_dir() {
+                docs = Some(path.to_owned());
+            }
+        } else if cfg!(unix) {
+            if let Some(path) = Some(ud.home_dir()) {
+                docs = Some(path.join(constants::LINUX_STEAM_PFX_PATH).to_owned());
+            }
+        } else {
+            unimplemented!();
         }
     }
 

--- a/src/core/scriptslog.rs
+++ b/src/core/scriptslog.rs
@@ -10,7 +10,64 @@ use crate::constants;
 /// the string passed to said printer will consist of one or more lines of text.
 pub fn tail_scriptslog<P>( printer: P, refresh_time_millis: u64, cancel_token: Receiver<()>, custom_path: Option<String> ) -> Option<String> 
 where P: Fn(&String) -> () {
-    match scriptslog_file(custom_path) {
+    if let Some(p) = custom_path {
+        tail_scriptslog_loop(Path::new(&p).to_path_buf(), printer, refresh_time_millis, cancel_token)
+    } else {
+        match scriptslog_file_path() {
+            Ok(p) => {
+                tail_scriptslog_loop(p, printer, refresh_time_millis, cancel_token)
+            }
+            Err(e) => {
+                Some(e)
+            }
+        }
+    }
+}
+
+fn scriptslog_file_path() -> Result<PathBuf, String> {
+    let mut docs = None;
+    if let Some(ud) = UserDirs::new() {
+        if cfg!(windows) {
+            if let Some(path) = ud.document_dir() {
+                docs = Some(path.to_owned());
+            }
+        } 
+        else if cfg!(unix) {
+            if let Some(path) = Some(ud.home_dir()) {
+                docs = Some(path.join(constants::LINUX_STEAM_PFX_PATH).to_owned());
+            }
+        } 
+        else {
+            unimplemented!();
+        }
+    }
+
+    if let Some(docs) = docs {
+        return Ok( docs.join(Path::new("The Witcher 3").join(constants::SCRIPTSLOG_FILE_NAME)) );
+    } else {
+        return Err( "Documents directory could not be found.".to_owned() );
+    }
+}
+
+fn open_scriptslog(path: &PathBuf) -> Result<File, String> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true) // so that it can be created if doesn't exist
+        .create(true)
+        .open(path);
+
+    if let Err(e) = file {
+        println!("{:?}", e.kind());
+        return Err("File open error: ".to_owned() + &e.to_string());
+    } else {
+        return Ok(file.unwrap());
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn tail_scriptslog_loop<P>(scriptslog_path: PathBuf, printer: P, refresh_time_millis: u64, cancel_token: Receiver<()>) -> Option<String> 
+where P: Fn(&String) -> () {
+    match open_scriptslog(&scriptslog_path) {
         Ok(file) => {
             let mut reader = BufReader::new(&file);
             // start from the end of the file
@@ -53,50 +110,61 @@ where P: Fn(&String) -> () {
         Err(e) => {
             Some(e)
         }
-    } 
+    }
 }
 
-fn scriptslog_file(custon_path: Option<String>) -> Result<File, String> {
-    let scriptslog_path: PathBuf;
-
-    if let Some(custom_path) = custon_path {
-        scriptslog_path = Path::new(&custom_path).to_owned();
-    } else if let Some(ud) = UserDirs::new() {
-        let mut docs = None;
-        if cfg!(windows) {
-            if let Some(path) = ud.document_dir() {
-                docs = Some(path.to_owned());
-            }
-        } 
-        else if cfg!(unix) {
-            if let Some(path) = Some(ud.home_dir()) {
-                docs = Some(path.join(constants::LINUX_STEAM_PFX_PATH).to_owned());
-            }
-        } 
-        else {
-            unimplemented!();
+#[cfg(target_os = "linux")]
+fn tail_scriptslog_loop<P>(scriptslog_path: PathBuf, printer: P, refresh_time_millis: u64, cancel_token: Receiver<()>) -> Option<String> 
+where P: Fn(&String) -> () {
+    let mut last_pos: u64;
+    match open_scriptslog(&scriptslog_path) {
+        Ok(file) => last_pos = file.metadata().unwrap().len(),
+        Err(e) => {
+            return Some(e)
         }
-
-        if let Some(docs) = docs {
-            scriptslog_path = docs.join(Path::new("The Witcher 3").join(constants::SCRIPTSLOG_FILE_NAME));
-        } else {
-            return Err( "Documents directory could not be found.".to_owned() );
+    }
+    
+    let mut text = String::new();
+    loop {
+        match cancel_token.try_recv() {
+            Ok(_) | Err(TryRecvError::Disconnected) => {
+                break;
+            }
+            Err(_) => {}
         }
+        
+        // on linux file system is different in a sense that we have to reopen the file to see the changes made to it
+        match open_scriptslog(&scriptslog_path) {
+            Ok(file) => {
+                let mut reader = BufReader::new(&file);
+                let filesize = file.metadata().unwrap().len();
 
-    } else {
-        return Err("Scriptslog path could not be resolved".to_owned());
+                if last_pos > filesize {
+                    last_pos = reader.seek(SeekFrom::Start(0)).unwrap();
+                } else {
+                    reader.seek(SeekFrom::Start(last_pos)).unwrap();
+                }
+
+                text.clear();
+                match reader.read_to_string(&mut text) {
+                    Ok(size) => {
+                        if size > 0 {
+                            last_pos += size as u64;
+                            printer(&text);
+                        }
+                    }
+                    Err(e) => {
+                        return Some("File read error: ".to_owned() + &e.to_string())
+                    }
+                }
+            }
+            Err(e) => {
+                return Some(e)
+            }
+        }
+        
+        std::thread::sleep( Duration::from_millis( refresh_time_millis ) );
     }
 
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true) // so that it can be created if doesn't exist
-        .create(true)
-        .open(scriptslog_path);
-
-    if let Err(e) = file {
-        println!("{:?}", e.kind());
-        return Err("File open error: ".to_owned() + &e.to_string());
-    } else {
-        return Ok(file.unwrap());
-    }
+    None
 }


### PR DESCRIPTION
Adds support for the Linux `scriptslog.txt` under the Steam prefix (non-functional with GOG <sub>yet</sub>). Anything other than Linux or Windows throws and unimplemented exception.
